### PR TITLE
remove extraneous returned function in useInterval

### DIFF
--- a/src/useInterval.js
+++ b/src/useInterval.js
@@ -25,8 +25,6 @@ function useInterval(callback, delay, runOnLoad = false, effectDependencies = []
       const id = setInterval(tick, delay);
       return () => clearInterval(id);
     }
-    
-    return () => null;
   }, [delay, ...effectDependencies]);
 };
 


### PR DESCRIPTION
returning `undefined` will work just as well