### PR TITLE
fix bug in useLocalStorage

### DIFF
--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -8,7 +8,7 @@ function useLocalStorage(key, initialValue) {
       // Get from local storage by key
       const item = window.localStorage.getItem(key);
       // Parse stored json or if none return initialValue
-      return item ? JSON.parse(item) : initialValue;
+      return item !== null ? JSON.parse(item) : initialValue;
     } catch (error) {
       // If error also return initialValue
       console.log(error);


### PR DESCRIPTION
if the previously saved value was falsy, you were returning the default value. this would happen for empty string, zero, and `false`. i changed this to compare for `null` (i.e. the value for no key found).