### PR TITLE
Allow React 17 in peer dependencies - closes #40

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
This PR should close issue #40 . 

Shamelessly inspired by [this](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/package.json#L47-L48).